### PR TITLE
#4 Improve reliability and test under Ubuntu 22.04.4 LTS

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -14,26 +14,33 @@
 # @author kgupta@sangoma.com
 #
 # This FreePBX install script and all concepts are property of
-# Sangoma Technologies. 
-# This install script is free to use for installing FreePBX 
+# Sangoma Technologies.
+# This install script is free to use for installing FreePBX
 # along with dependent packages only but carries no guarnatee on performance
 # and is used at your own risk.  This script carries NO WARRANTY.
 #####################################################################################
-#                                               FreePBX 17              #
+#                                               FreePBX 17                          #
 #####################################################################################
+set -e
 SCRIPTVER="1.0"
 ASTVERSION=21
-LOG_FILE='/var/log/pbx/freepbx17-install.log'
+AACVERSION="2.0.1-1"
+PHPVERSION="8.2"
+LOG_FOLDER="/var/log/pbx"
+LOG_FILE="${LOG_FOLDER}/freepbx17-install-$(date '+%Y.%m.%d-%H.%M.%S').log"
+DISTRIBUTION="$(lsb_release -is)"
 log=$LOG_FILE
-mkdir -p '/var/log/pbx/'
-echo "" > $log
-#####################################################################################
+
 # Check for root privileges
 if [[ $EUID -ne 0 ]]; then
-   echo "This script must be run as root" 
+   echo "This script must be run as root"
    exit 1
 fi
-#####################################################################################
+
+mkdir -p "${LOG_FOLDER}"
+echo "" > $log
+
+# Get parameters
 POSITIONAL_ARGS=()
 
 while [[ $# -gt 0 ]]; do
@@ -62,8 +69,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 
-################################################################################################################
-################################################################################################################
 #Helpers APIs
 exec 2>>${LOG_FILE}
 
@@ -74,17 +79,31 @@ log() {
 
 message() {
 	echo "$(date +"%Y-%m-%d %T") - $*"
-	echo "$(date +"%Y-%m-%d %T") - $*" >> "$LOG_FILE"
+	log "$*"
 }
 
-# Function to exit the process 
+#Function to record and display the current step
+setCurrentStep () {
+	currentStep="$1"
+	message "${currentStep}"
+}
+
+# Function to cleanup installation
 terminate() {
 	# removing pid file
-	rm -rf $pidfile
-	exit 0;
+	message "Exiting script"
+	rm -f "$pidfile"
 }
 
-# Checking if the package is already installed or not 
+#Function to log error and location
+errorHandler() {
+	log "****** INSTALLATION FAILED *****"
+	message "Installation failed at step ${currentStep}. Please check log ${LOG_FILE} for details."
+	message "Error at line line: $1 exiting with code $2 (last command was: $3)"
+	exit "$2"
+}
+
+# Checking if the package is already installed or not
 isinstalled() {
 	PKG_OK=$(/usr/bin/dpkg-query -W --showformat='${Status}\n' "$@" 2>/dev/null|grep "install ok installed")
 	if [ "" = "$PKG_OK" ]; then
@@ -94,24 +113,11 @@ isinstalled() {
 	fi
 }
 
-# Function to install the package 
+# Function to install the package
 pkg_install() {
-	log "############################### "
 	PKG=$@
-	if isinstalled $PKG; then
-		log "$PKG already present ...."
-	else 
-		message "Installing $PKG Now ...."
-		apt-get -y --ignore-missing -o DPkg::Options::="--force-confnew" -o Dpkg::Options::="--force-overwrite" install $PKG >> $log 2>&1
-		if isinstalled $PKG; then
-			message "$PKG installed successfully...."
-		else 
-			message "$PKG failed to install ...."
-			message "Exiting the installation process as dependent $PKG failed to install ...."
-			terminate
-		fi
-	fi
-	log "############################### "
+	log "Installing $PKG"
+	apt -y -o DPkg::Options::="--force-confnew" -o Dpkg::Options::="--force-overwrite" install $PKG >> $log 2>&1
 }
 
 # Function to install the mongodb
@@ -121,24 +127,21 @@ install_mongodb() {
 	else
 		message "Installing  mongodb...."
 		# Ref - https://medium.com/@arun0808rana/mongodb-installation-on-debian-12-8001d0dafb56
-		apt-get -y --ignore-missing install gnupg curl >> "$log" 2>&1
-		curl -fsSL https://pgp.mongodb.com/server-7.0.asc | gpg  --dearmor -o /etc/apt/trusted.gpg.d/mongodb-server-7.0.gpg >> "$log" 2>&1
-		echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-7.0.list >> "$log" 2>&1
-		apt-get update >> "$log" 2>&1
 		apt-get install -y mongodb-org >> "$log" 2>&1
 
 		if isinstalled mongodb-org; then
 			message "Mongodb installed successfully...."
-		else 
+		else
 			message "Mongodb failed to install ...."
+			exit 1
 		fi
-	fi 
+	fi
 }
 
 # Function to install the asterisk and dependent packages
 install_asterisk() {
 	astver=$1
-	ASTPKGS=("addons" 
+	ASTPKGS=("addons"
 		"addons-bluetooth"
 		"addons-core"
 		"addons-mysql"
@@ -159,159 +162,206 @@ install_asterisk() {
 		"voicemail"
 	)
 
-	# creating directories 
+	# creating directories
 	mkdir -p /var/lib/asterisk/moh
-	pkg_install asterisk$astver
 
+	asteriskPkgs=""
 	for i in "${!ASTPKGS[@]}"; do
-		pkg_install asterisk$astver-${ASTPKGS[$i]}
+		asteriskPkgs="${asteriskPkgs} asterisk$astver-${ASTPKGS[$i]}"
 	done
 
-	pkg_install asterisk$astver.0-freepbx-asterisk-modules
-	pkg_install asterisk-version-switch
-	pkg_install asterisk-sounds-*
+    allAsteriskPkg=("asterisk$astver ${asteriskPkgs} asterisk$astver.0-freepbx-asterisk-modules asterisk-version-switch asterisk-sounds-*")
+
+	pkg_install ${allAsteriskPkg[*]}
 }
 
-################################################################################################################
+setup_repositories() {
+	#Add PHP 8.2
+	wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+	if [ "${DISTRIBUTION}" = "Ubuntu" ]; then
+	    add-apt-repository -y "ppa:ondrej/php" >> "$log" 2>&1
+	    add-apt-repository -y "ppa:ondrej/apache2" >> "$log" 2>&1
+	else
+		add-apt-repository -y -S "deb [ arch=${arch} ] https://packages.sury.org/php/ $(lsb_release -sc) main" >> "$log" 2>&1
+	fi
+
+	apt-key del "9641 7C6E 0423 6E0A 986B  69EF DE82 7447 3C8D 0E52" >> "$log" 2>&1
+
+	wget -qO - http://deb.freepbx.org/gpg/aptly-pubkey.asc | gpg --dearmor --yes -o /etc/apt/trusted.gpg.d/freepbx.gpg  >> "$log" 2>&1
+
+	# Setting our default repo server
+	if [ $testrepo ] ; then
+		add-apt-repository -y -S "deb [ arch=${arch} ] http://deb.freepbx.org/freepbx17-dev bookworm main" >> "$log" 2>&1
+	else
+		add-apt-repository -y -S "deb [ arch=${arch} ] http://deb.freepbx.org/freepbx17-prod bookworm main" >> "$log" 2>&1
+	fi
+
+	wget -qO - https://pgp.mongodb.com/server-7.0.asc | gpg  --dearmor --yes -o /etc/apt/trusted.gpg.d/mongodb-server-7.0.gpg >> "$log" 2>&1
+	add-apt-repository -y -S "deb [ arch=${arch} ] https://repo.mongodb.org/apt/ubuntu jammy/mongodb-org/7.0 multiverse" >> "$log" 2>&1
+
+	setCurrentStep "Setting up Sangoma repository"
+cat <<EOF> /etc/apt/preferences.d/99sangoma-fpbx-repository
+# Allways prefer packages from deb.freepbx.org
+
+Package: *
+Pin: origin deb.freepbx.org
+Pin-Priority: ${MIRROR_PRIO}
+EOF
+}
+
+
 ################################################################################################################
 MIRROR_PRIO=600
 kernel=`uname -a`
+arch=`dpkg --print-architecture`
 host=`hostname`
-pidfile='/var/run/freepbx17.pid'
+fqdn="$(hostname -f)"
 
+#Ensure the script is not running
+pid="$$"
+pidfile='/var/run/freepbx17_installer.pid'
 
 if [ -f "$pidfile" ]; then
-	message "FreePBX 17 installation process is already going on, hence not starting new process"
-	message "If FreePBX 17 installation process is NOT running then delete $pidfile file and try again."
-	exit 1;
+	log "Previous PID file found."
+	if ps -p "${pid}" > /dev/null
+	then
+		message "FreePBX 17 installation process is already going on (PID=${pid}), hence not starting new process"
+		exit 1;
+	fi
+	log "Removing stale PID file"
+	rm -f "${pidfile}"
 fi
 
-start=$(date +%s.%N)
+setCurrentStep "Starting installation."
+trap 'errorHandler "$LINENO" "$?" "$BASH_COMMAND"' ERR
+trap "terminate" EXIT
+echo "${pid}" > $pidfile
+
+start=$(date +%s)
 message "  Starting FreePBX 17 installation process for $host $kernel"
 message "  Please refer to the $log to know the process..."
 log "  Executing script v$SCRIPTVER ..."
-touch $pidfile
 
-################################################################################################################
-
-########################################################################################
-# Step-1 : Install dependent packages
-########################################################################################
-#
-log "############################### "
-message "###### STEP-1 Installing dependent packages process - BEGIN ######################### "
-
+setCurrentStep "Making sure installation is sane"
 # Fixing broken install
-apt --fix-broken install >> $log 2>&1
-# update repos
+apt -y --fix-broken install >> $log 2>&1
+apt autoremove -y >> "$log" 2>&1
+
+setCurrentStep "Setting up repositories"
+setup_repositories
+
+setCurrentStep "Updating repository"
 apt update >> $log 2>&1
 
+# log the apt-cache policy
+apt-cache policy  >> $log 2>&1
 
-# Adding iptables and postfix  inputs so "iptables-persistent" and postfix will not ask for the input 
+# Adding iptables and postfix  inputs so "iptables-persistent" and postfix will not ask for the input
+setCurrentStep "Setting up default configuration"
 debconf-set-selections <<EOF
 iptables-persistent iptables-persistent/autosave_v4 boolean true
 iptables-persistent iptables-persistent/autosave_v6 boolean true
 EOF
-echo "postfix postfix/mailname string my.hostname.example" | debconf-set-selections
+echo "postfix postfix/mailname string ${fqdn}" | debconf-set-selections
 echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections
 
 # Install dependent packages
-DEPPKGS=("redis-server" 
-	"bc" 
-	"libsnmp-dev" 
-	"libtonezone-dev" 
-	"libpq-dev" 
-	"liblua5.2-dev" 
-	"libpri-dev" 
-	"libbluetooth-dev" 
-	"libunbound-dev" 
-	"libsybdb5" 
-	"libspeexdsp-dev" 
-	"libiksemel-dev" 
-	"libresample1-dev" 
-	"libgmime-3.0-dev" 
-	"libc-client2007e-dev" 
-	"dpkg-dev" 
-	"ghostscript" 
-	"libtiff-tools" 
-	"iptables-persistent" 
-	"net-tools" 
-	"rsyslog" 
-	"libavahi-client3" 
-	"nmap" 
-	"apache2" 
-	"zip" 
-	"incron" 
-	"chrony" 
-	"wget" 
-	"vim" 
-	"build-essential" 
-	"openssh-server" 
-	"apache2" 
-	"mariadb-server" 
-	"mariadb-client" 
-	"bison" 
-	"flex" 
-	"flite" 
-	"php8.2" 
-	"php8.2-curl" 
-	"php8.2-zip" 
-	"php8.2-redis" 
-	"php8.2-curl" 
-	"php8.2-cli" 
-	"php8.2-common" 
-	"php8.2-mysql" 
-	"php8.2-gd" 
-	"php8.2-mbstring" 
-	"php8.2-intl" 
-	"php8.2-xml" 
-	"php8.2-bz2" 
-	"php8.2-ldap" 
-	"php-soap" 
-	"php-pear" 
-	"curl" 
-	"sox" 
-	"libncurses5-dev" 
-	"libssl-dev" 
-	"mpg123" 
-	"libxml2-dev" 
-	"libnewt-dev" 
-	"sqlite3" 
-	"libsqlite3-dev" 
-	"pkg-config" 
-	"automake" 
-	"libtool" 
-	"autoconf" 
-	"git" 
-	"unixodbc-dev" 
-	"uuid" 
-	"uuid-dev" 
-	"libasound2-dev" 
-	"libogg-dev" 
-	"libvorbis-dev" 
-	"libicu-dev" 
-	"libcurl4-openssl-dev" 
-	"odbc-mariadb" 
-	"libical-dev" 
-	"libneon27-dev" 
-	"libsrtp2-dev" 
-	"libspandsp-dev" 
-	"sudo" 
-	"subversion" 
-	"libtool-bin" 
-	"python-dev-is-python3" 
-	"unixodbc" 
-	"libjansson-dev" 
-	"nodejs" 
-	"npm" 
-	"ipset" 
-	"iptables" 
-	"fail2ban" 
-	"htop" 
-	"liburiparser-dev" 
-	"postfix" 
-	"tcpdump" 
-	"sngrep" 
+setCurrentStep "Installing required packages"
+DEPPKGS=("redis-server"
+	"libsnmp-dev"
+	"libtonezone-dev"
+	"libpq-dev"
+	"liblua5.2-dev"
+	"libpri-dev"
+	"libbluetooth-dev"
+	"libunbound-dev"
+	"libsybdb5"
+	"libspeexdsp-dev"
+	"libiksemel-dev"
+	"libresample1-dev"
+	"libgmime-3.0-dev"
+	"libc-client2007e-dev"
+	"dpkg-dev"
+	"ghostscript"
+	"libtiff-tools"
+	"iptables-persistent"
+	"net-tools"
+	"rsyslog"
+	"libavahi-client3"
+	"nmap"
+	"apache2"
+	"zip"
+	"incron"
+	"chrony"
+	"wget"
+	"vim"
+	"build-essential"
+	"openssh-server"
+	"apache2"
+	"mariadb-server"
+	"mariadb-client"
+	"bison"
+	"flex"
+	"flite"
+	"php${PHPVERSION}"
+	"php${PHPVERSION}-curl"
+	"php${PHPVERSION}-zip"
+	"php${PHPVERSION}-redis"
+	"php${PHPVERSION}-curl"
+	"php${PHPVERSION}-cli"
+	"php${PHPVERSION}-common"
+	"php${PHPVERSION}-mysql"
+	"php${PHPVERSION}-gd"
+	"php${PHPVERSION}-mbstring"
+	"php${PHPVERSION}-intl"
+	"php${PHPVERSION}-xml"
+	"php${PHPVERSION}-bz2"
+	"php${PHPVERSION}-ldap"
+	"php-soap"
+	"php-pear"
+	"curl"
+	"sox"
+	"libncurses5-dev"
+	"libssl-dev"
+	"mpg123"
+	"libxml2-dev"
+	"libnewt-dev"
+	"sqlite3"
+	"libsqlite3-dev"
+	"pkg-config"
+	"automake"
+	"libtool"
+	"autoconf"
+	"git"
+	"unixodbc-dev"
+	"uuid"
+	"uuid-dev"
+	"libasound2-dev"
+	"libogg-dev"
+	"libvorbis-dev"
+	"libicu-dev"
+	"libcurl4-openssl-dev"
+	"odbc-mariadb"
+	"libical-dev"
+	"libneon27-dev"
+	"libsrtp2-dev"
+	"libspandsp-dev"
+	"sudo"
+	"subversion"
+	"libtool-bin"
+	"python-dev-is-python3"
+	"unixodbc"
+	"libjansson-dev"
+	"nodejs"
+	"npm"
+	"ipset"
+	"iptables"
+	"fail2ban"
+	"htop"
+	"liburiparser-dev"
+	"postfix"
+	"tcpdump"
+	"sngrep"
 	"libavdevice-dev"
 	"tftpd-hpa"
 	"xinetd"
@@ -321,73 +371,66 @@ DEPPKGS=("redis-server"
 	"easy-rsa"
 	"openvpn"
 	"sysstat"
+	"software-properties-common"
+	"gnupg"
+	"apt-transport-https"
+	"lsb-release"
+	"ca-certificates"
 )
 
-for i in "${!DEPPKGS[@]}"; do
-	pkg_install ${DEPPKGS[$i]}
-done
+allpkg="${DEPPKGS[*]}"
+pkg_install "${allpkg}"
 
 # Install mongod
+setCurrentStep "Setting up MongoDB"
 install_mongodb
 
 # Install libfdk
-if isinstalled libfdk-aac2; then
+setCurrentStep "Setting up libfdk"
+if isinstalled libfdk-aac-dev; then
 	log "libfdk-aac2 already present...."
 else
-	wget http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_2.0.1-1_amd64.deb -O /tmp/libfdk-aac2_2.0.1-1_amd64.deb >> "$log" 2>&1
-	wget http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_2.0.1-1_amd64.deb -O /tmp/libfdk-aac-dev_2.0.1-1_amd64.deb >> "$log" 2>&1
-	dpkg -i /tmp/libfdk-aac2_2.0.1-1_amd64.deb >> "$log" 2>&1
-	dpkg -i /tmp/libfdk-aac-dev_2.0.1-1_amd64.deb >> "$log" 2>&1
+	wget "http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
+	wget "http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac2_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
+	dpkg -i /tmp/libfdk-aac2_${AACVERSION}_${arch}.deb >> "$log" 2>&1
+	dpkg -i /tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb >> "$log" 2>&1
+	rm -f /tmp/libfdk-aac2_${AACVERSION}_${arch}.deb >> "$log" 2>&1
+	rm -f /tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb >> "$log" 2>&1
 fi
 
+setCurrentStep "Removing unnecessary packages"
 apt autoremove -y >> "$log" 2>&1
 
-duration=$(echo "$(date +%s.%N) - $start" | bc)
-execution_time=`printf "%.2f seconds" $duration`
-message "Execution time to install all the dependent packages : $execution_time"
-message " ###### STEP-1 END #########################  "
-########################################################################################
-# Step-2 : Perform pre-requisite steps
-########################################################################################
-########################################################################################
-log "############################### "
-message "###### STEP-2 Performing pre requisite steps BEGIN ######################### "
+execution_time="$(($(date +%s) - $start))"
+message "Execution time to install all the dependent packages : $execution_time s"
 
-# Add preference file
-cat <<EOF> /etc/apt/preferences.d/99sangoma-fpbx-repository
-# Allways prefer packages from deb.freepbx.org
+setCurrentStep "Setting up folders and asterisk config"
+groupExists="`getent group asterisk || echo ''`"
+if [ "${groupExists}" = "" ]; then
+	groupadd -r asterisk
+fi
 
-Package: *
-Pin: origin deb.freepbx.org
-Pin-Priority: ${MIRROR_PRIO}
-EOF
-
-pkg_install software-properties-common
-pkg_install gnupg
-
-# Delete old key 
-apt-key del "9641 7C6E 0423 6E0A 986B  69EF DE82 7447 3C8D 0E52"
-
-wget -qO - http://deb.freepbx.org/gpg/aptly-pubkey.asc | apt-key add - >> "$log" 2>&1
-
-message " ###### STEP-2 END #########################  "
-
-groupadd -r asterisk
-useradd -r -g asterisk -d /home/asterisk -M -s /bin/bash asterisk
+userExists="`getent passwd asterisk || echo ''`"
+if [ "${userExists}" = "" ]; then
+	useradd -r -g asterisk -d /home/asterisk -M -s /bin/bash asterisk
+fi
 
 # Adding asterisk to the sudoers list
 #echo "%asterisk ALL=(ALL:ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Creating /tftpboot directory
 mkdir -p /tftpboot
-# Creating asterisk sound directory 
+# Creating asterisk sound directory
 mkdir -p /var/lib/asterisk/sounds
 chown -R asterisk:asterisk /var/lib/asterisk
 
 # Changing openssl to make it compatible with the katana
 sed -i -e 's/^openssl_conf = openssl_init$/openssl_conf = default_conf/' /etc/ssl/openssl.cnf
 
-cat <<EOF >> /etc/ssl/openssl.cnf
+isSSLConfigAdapted=$(grep "FreePBX 17 changes" /etc/ssl/openssl.cnf |wc -l)
+if [ "0" = "${isSSLConfigAdapted}" ]; then
+	cat <<EOF >> /etc/ssl/openssl.cnf
+# FreePBX 17 changes - begin
 [ default_conf ]
 ssl_conf = ssl_sect
 [ssl_sect]
@@ -395,31 +438,44 @@ system_default = system_default_sect
 [system_default_sect]
 MinProtocol = TLSv1.2
 CipherString = DEFAULT:@SECLEVEL=1
+# FreePBX 17 changes - end
 EOF
-
+fi
 
 #Disabling ipv6 to avoid localhost to resolving to ipv6 address (which could break nodeJs)
-cat <<EOF >> /etc/sysctl.conf
+isIPv6Disabled=$(grep "FreePBX 17 changes" /etc/sysctl.conf |wc -l)
+if [ "0" = "${isIPv6Disabled}" ]; then
+	cat <<EOF >> /etc/sysctl.conf
+# FreePBX 17 changes - begin
 net.ipv6.conf.all.disable_ipv6 = 1
 net.ipv6.conf.default.disable_ipv6 = 1
 net.ipv6.conf.lo.disable_ipv6 = 1
+# FreePBX 17 changes - end
 EOF
-/usr/sbin/sysctl -p >> $log 2>&1
+	/usr/sbin/sysctl -p >> $log 2>&1
+fi
 
 
-# Setting screen configuration 
-cat <<EOF >> /root/.screenrc
+# Setting screen configuration
+isScreenRcAdapted=$(grep "FreePBX 17 changes" /root/.screenrc |wc -l)
+if [ "0" = "${isScreenRcAdapted}" ]; then
+	cat <<EOF >> /root/.screenrc
+# FreePBX 17 changes - begin
 hardstatus alwayslastline
 hardstatus string '%{= kG}[ %{G}%H %{g}][%= %{=kw}%?%-Lw%?%{r}(%{W}%n*%f%t%?(%u)%?%{r})%{w}%?%+Lw%?%?%= %{g}][%{B}%Y-%m-%d %{W}%c %{g}]'
+# FreePBX 17 changes - end
 EOF
+fi
 
 
 # Setting VIM configuration for mouse copy paste
-VIMRUNTIME=`vim -e -T dumb --cmd 'exe "set t_cm=\<C-M>"|echo $VIMRUNTIME|quit' | tr -d '\015' `
+isVimRcAdapted=$(grep "FreePBX 17 changes" /etc/vim/vimrc.local |wc -l)
+if [ "0" = "${isVimRcAdapted}" ]; then
+	VIMRUNTIME=`vim -e -T dumb --cmd 'exe "set t_cm=\<C-M>"|echo $VIMRUNTIME|quit' | tr -d '\015' `
+	VIMRUNTIME_FOLDER=`echo $VIMRUNTIME | sed 's/ //g'`
 
-VIMRUNTIME_FOLDER=`echo $VIMRUNTIME | sed 's/ //g'`
-
-cat <<EOF >> /etc/vim/vimrc.local
+	cat <<EOF >> /etc/vim/vimrc.local
+" FreePBX 17 changes - begin
 " This file loads the default vim options at the beginning and prevents
 " that they are being loaded again later. All other options that will be set,
 " are added, or overwrite the default settings. Add as many options as you
@@ -440,100 +496,77 @@ let skip_defaults_vim = 1
 if has('mouse')
   set mouse=r
 endif
+" FreePBX 17 changes - end
 EOF
-
-message "###### STEP-2 END ######################### "
-
-########################################################################################
-# Step-3 : Set the Sangoma Debian repository to download Sangoma freepbx17 packages
-########################################################################################
-#
-log "############################### "
-message "###### STEP-3 Installing Sangoma dependent packages BEGIN ######################### "
-
-# Setting our default repo server
-if [ $testrepo ] ; then
-	add-apt-repository -y -S 'deb http://deb.freepbx.org/freepbx17-dev bookworm main' >> "$log" 2>&1
-	add-apt-repository -y -S 'deb http://deb.freepbx.org/freepbx17-dev bookworm main' >> "$log" 2>&1
-else
-	add-apt-repository -y -S 'deb http://deb.freepbx.org/freepbx17-prod bookworm main' >> "$log" 2>&1
-	add-apt-repository -y -S 'deb http://deb.freepbx.org/freepbx17-prod bookworm main' >> "$log" 2>&1
 fi
 
-# Updating the new repo
-apt update >> $log 2>&1
-
-# log the apt-cache policy 
-apt-cache policy  >> $log 2>&1
 
 #chown -R asterisk:asterisk /etc/ssl
 
 # Install Asterisk
 if [ $noast ] ; then
 	message "Skipping Asterisk RPM installation due to noastrisk option"
-else 
+else
 	# TODO Need to check if asterisk installed already then remove that and install new ones.
 	# Install Asterisk 21
+	setCurrentStep "Installing Asterisk packages."
 	install_asterisk $ASTVERSION
 fi
 
-message "Installing FreePBX dependent packages"
 # Install PBX dependent RPMs
-pkg_install ioncube-loader-82
-pkg_install sysadmin17
-pkg_install sangoma-pbx17
-pkg_install ffmpeg
+setCurrentStep "Installing FreePBX packages"
+pkg_install "ioncube-loader-82" "sysadmin17" "sangoma-pbx17" "ffmpeg"
+
 #Enabling freepbx.ini file
+setCurrentStep "Enabling modules."
 /usr/sbin/phpenmod freepbx
 mkdir -p /var/lib/php/session
 
 #Creating default config files
+mkdir -p /etc/asterisk
 touch /etc/asterisk/extconfig_custom.conf
 touch /etc/asterisk/extensions_override_freepbx.conf
 touch /etc/asterisk/extensions_additional.conf
 touch /etc/asterisk/extensions_custom.conf
 chown -R asterisk:asterisk /etc/asterisk
 
-
+setCurrentStep "Restating fail2ban"
 log "Restarting fail2ban "
 /usr/bin/systemctl restart fail2ban  >> $log
 
-message "###### STEP-3 END ######################### "
-#
-#
-########################################################################################
-# Step-4 : Install FreePBX
-########################################################################################
-log "############################### "
-message "###### STEP-4 Installing FreePBX BEGIN ######################### "
 
 if [ $nofpbx ] ; then
 	message "Skipping FreePBX 17 fresh tarball installation due to nofreepbx option"
-else 
-	pkg_install freepbx17 
+else
+	setCurrentStep "Installing FreePBX 17"
+	pkg_install freepbx17
 fi
 
 # Reinstalling modules to ensure all the modules are enabled/installed
+setCurrentStep "Installing Sysadmin module"
 fwconsole ma install sysadmin >> $log 2>&1
-message "Installing FreePBX 17 modules.."
-fwconsole ma installlocal >> $log 2>&1 
-message "Upgrading FreePBX 17 modules.."
-fwconsole ma upgradeall >> $log 2>&1 
-message "Executing fwconsole reload/restart .."
-fwconsole reload >> $log 2>&1 
-fwconsole restart >> $log 2>&1 
 
-message "###### STEP-4 END ######################### "
-########################################################################################
-# Final system wrapup
-#
-########################################################################################
-message "Wrapping up the installation process.."
+#Not installing sangoma connect result in failure of first installlocal
+setCurrentStep "Installing sangomaconnectmodule"
+fwconsole ma install sangomaconnect>> $log 2>&1
+
+setCurrentStep "Installing install local module"
+fwconsole ma installlocal >> $log 2>&1
+
+setCurrentStep "Upgrading FreePBX 17 modules"
+fwconsole ma upgradeall >> $log 2>&1
+
+setCurrentStep "reloading and restarting FreePBX 17"
+fwconsole reload >> $log 2>&1
+fwconsole restart >> $log 2>&1
+
+
+setCurrentStep "Wrapping up the installation process"
 systemctl daemon-reload >> "$log" 2>&1
 systemctl enable freepbx >> "$log" 2>&1
 
 #delete apache2 index.html as we do not need that file
-rm -f /var/www/html/index.html  
+rm -f /var/www/html/index.html
 
 #enable apache mod ssl
 /usr/sbin/a2enmod ssl  >> "$log" 2>&1
@@ -541,7 +574,7 @@ rm -f /var/www/html/index.html
 #enable apache mod expires
 /usr/sbin/a2enmod expires  >> "$log" 2>&1
 
-#enable apache 
+#enable apache
 a2enmod rewrite >> "$log" 2>&1
 
 #Enabling freepbx apache configuration
@@ -553,22 +586,20 @@ cd /etc/apache2/sites-enabled/ && ln -s ../sites-available/freepbx.conf freepbx.
 # Restart apache2
 systemctl restart apache2 >> "$log" 2>&1
 
-# Refresh signatures 
-/usr/sbin/fwconsole ma refreshsignatures >> "$log" 2>&1
+# Refresh signatures
+fwconsole ma refreshsignatures >> "$log" 2>&1
 
 #Do not want to upgrade initial(first time setup) packages
 apt-mark hold freepbx17
 apt-mark hold sangoma-pbx17
 
+setCurrentStep "Installation successful."
+
 ############ TODO - POST INSTALL VALIDATION ############################################
-########################################################################################
-duration=$(echo "$(date +%s.%N) - $start" | bc)
-execution_time=`printf "%.2f seconds" $duration`
+
+execution_time="$(($(date +%s) - $start))"
 message "Total script Execution Time: $execution_time"
 message "Finished FreePBX 17 installation process for $host $kernel"
 message "Join us on the FreePBX Community Forum: https://community.freepbx.org/ ";
-########################################################################################
-/usr/sbin/fwconsole motd
-########################################################################################
-terminate
-########################################################################################
+
+fwconsole motd


### PR DESCRIPTION
Improved the script by

- adding error handling (trap and set -e)
- made idempotent (example do not add the same lines to config files multiple time, do not attempt to create the user and group multiple time)
- Update all repositories before th first run to ensure we have consistent packages and version
- made log file unique (so we keep an history of the executions)
- Improved speed by installing many packages in one go instead of one at a time
- Ensured that signing keys are correctly added (using the new gpg signatures instead of the deprecated add-key)
- Ensure only installed architecture is referenced (not arm64 when the system is an amd64 and vice-versa)
- Use the fully qualified host name to setup postfix
- Remove bc as it is only used to compute processing time (up to the hundreds of seconds, while it takes minutes to run (the hundreds of seconds are irrelevant)
- added fwconsole ma install sangomaconnect as without it, the installlocal was failing