### PR TITLE
Fix small problems

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -189,7 +189,7 @@ install_asterisk() {
 }
 
 setup_repositories() {
-	#Add PHP 8.2
+	#Add PHP repository
 	wget -O /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 	if [ "${DISTRIBUTION}" = "Ubuntu" ]; then
 	    add-apt-repository -y "ppa:ondrej/php" >> "$log" 2>&1
@@ -616,7 +616,7 @@ cd /etc/apache2/sites-enabled/ && ln -s ../sites-available/freepbx.conf freepbx.
 /usr/sbin/postconf -e message_size_limit=102400000
 
 # Disable expose_php for provide less information to attacker
-sed -i 's/\(^expose_php = \).*/\1Off/' /etc/php/8.2/apache2/php.ini
+sed -i 's/\(^expose_php = \).*/\1Off/' /etc/php/${PHPVERSION}/apache2/php.ini
 
 # Disable ServerTokens and ServerSignature for provide less information to attacker
 sed -i 's/\(^ServerTokens \).*/\1Prod/' /etc/apache2/conf-available/security.conf

--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -411,8 +411,8 @@ setCurrentStep "Setting up libfdk"
 if isinstalled libfdk-aac-dev; then
 	log "libfdk-aac2 already present...."
 else
-	wget "http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
-	wget "http://ftp.us.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac2_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
+	wget "http://deb.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac-dev_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
+	wget "http://deb.debian.org/debian/pool/non-free/f/fdk-aac/libfdk-aac2_${AACVERSION}_${arch}.deb" -O "/tmp/libfdk-aac2_${AACVERSION}_${arch}.deb" >> "$log" 2>&1
 	dpkg -i /tmp/libfdk-aac2_${AACVERSION}_${arch}.deb >> "$log" 2>&1
 	dpkg -i /tmp/libfdk-aac-dev_${AACVERSION}_${arch}.deb >> "$log" 2>&1
 	rm -f /tmp/libfdk-aac2_${AACVERSION}_${arch}.deb >> "$log" 2>&1

--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -537,7 +537,7 @@ else
 	install_asterisk $ASTVERSION
 fi
 
-# Install PBX dependent RPMs
+# Install PBX dependent packages
 setCurrentStep "Installing FreePBX packages"
 FPBXPKGS=("ioncube-loader-82"
 	   "sysadmin17"


### PR DESCRIPTION
This PR fixes the following three small problems:

1. Disable expose_php for provide less information to attacker should care new add PHPVERSION.
2. Debian doesn't have RPM, so need remove it.
3. Using Debian global CDN to download libfdk.