### PR TITLE
Update FreePBX Apache Configuration Enablement to Use a2ensite Command

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -635,7 +635,7 @@ rm -f /var/www/html/index.html
 a2enmod rewrite >> "$log" 2>&1
 
 #Enabling freepbx apache configuration
-cd /etc/apache2/sites-enabled/ && ln -s ../sites-available/freepbx.conf freepbx.conf >> "$log" 2>&1
+a2ensite freepbx.conf
 
 #Setting postfix size to 100MB
 /usr/sbin/postconf -e message_size_limit=102400000


### PR DESCRIPTION
**Description:**
This pull request replaces the manual creation of symbolic links for enabling FreePBX Apache configuration with the usage of the a2ensite command. The a2ensite command is a standard method for enabling Apache site configurations on Debian-based systems like FreePBX. This change simplifies the process, improves readability, and aligns with best practices for managing Apache configurations.