### PR TITLE
Add a check for allowable system architecture.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -666,6 +666,14 @@ else
     check_version
 fi
 
+# Check if we are running on a 64-bit system
+ARCH=$(dpkg --print-architecture)
+if [ "$ARCH" != "amd64" ]; then
+    message "FreePBX 17 installation can only be made on a 64-bit (amd64) system!"
+    message "Current System's Architecture: $ARCH"
+    exit 1
+fi
+
 # Check if hostname command succeeded and FQDN is not empty
 if [ -z "$fqdn" ]; then
     echo "Fully qualified domain name (FQDN) is not set correctly."


### PR DESCRIPTION
Abort installation with a meaningful message if trying to do it in a system with an architecture different from `amd64`.
This is to avoid users to be confused when they try to install FreePBX on a `i386` system (e.g. https://github.com/FreePBX/issue-tracker/issues/403).