### PR TITLE
Always set a sane PATH for script execution.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -37,10 +37,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 # Setup a sane PATH for script execution as root
-if ! grep -q "export PATH=$SANE_PATH" /root/.bashrc; then
-  echo "export PATH=$SANE_PATH" >> /root/.bashrc
-  export PATH=$SANE_PATH
-fi
+export PATH=$SANE_PATH
 
 while [[ $# -gt 0 ]]; do
 	case $1 in


### PR DESCRIPTION
In situations were the user has an environment were PATH does not include `/usr/sbin` and/or `/sbin` and switches to root in a way that the environment is preserved, the script will abort when trying to execute commands stored in those paths.
This PR fixes #111.