### PR TITLE
Redirect "apt-mark hold" output to log file.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -637,15 +637,15 @@ check_asterisk() {
 }
 
 hold_packages() {
-    if [ ! $nofpbx ] ; then
-      apt-mark hold freepbx17
-    fi
     # List of package names to hold
     local packages=("sangoma-pbx17" "nodejs" "node-*")
+    if [ ! $nofpbx ] ; then
+        packages+=("freepbx17")
+    fi
 
     # Loop through each package and hold it
     for pkg in "${packages[@]}"; do
-        apt-mark hold "$pkg"
+        apt-mark hold "$pkg" >> "$log"
     done
 }
 


### PR DESCRIPTION
The `apt-mark hold` command is "polluting" the script's console output, because it's holding Node.js packages, and Debian delivers those into a lot (371 !) of small packages. I think it's better to redirect that command output to the log file, to keep the script's console output concise, in order it's easily understood by non-expert users.