### PR TITLE
Remove changes on apache service.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -1140,18 +1140,6 @@ sed -i 's/\(^expose_php = \).*/\1Off/' /etc/php/${PHPVERSION}/apache2/php.ini
 sed -i 's/\(^ServerTokens \).*/\1Prod/' /etc/apache2/conf-available/security.conf
 sed -i 's/\(^ServerSignature \).*/\1Off/' /etc/apache2/conf-available/security.conf
 
-# Make sure that the apache service start after freepbx service is started
-if [ -e "/lib/systemd/system/apache2.service" ]; then
-    if [ -e "/lib/systemd/system/freepbx.service" ]; then
-        is_fpbx_pres=$(grep -nr "freepbx.service" /lib/systemd/system/apache2.service | wc -l)
-
-        if [ $is_fpbx_pres -eq 0 ]; then
-            sed -i '/After=/s/$/ freepbx.service/' /lib/systemd/system/apache2.service
-        fi
-    fi
-fi
-
-
 # Restart apache2
 systemctl restart apache2 >> "$log"
 


### PR DESCRIPTION
Latest `freepbx17` package already ships a corrected `freepbx.service` with `After=apache2.service` config, so the changes made by the installation script in the `apache2.service` should be removed.

Fixes https://github.com/FreePBX/sng_freepbx_debian_install/issues/114