### PR TITLE
Enable apache vhost default-ssl

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -1128,6 +1128,7 @@ a2enmod rewrite >> "$log"
 #Enabling freepbx apache configuration
 if [ ! $nofpbx ] ; then 
   a2ensite freepbx.conf >> "$log"
+  a2ensite default-ssl >> "$log"
 fi
 
 #Setting postfix size to 100MB


### PR DESCRIPTION
Since port 443 is already open in ports.conf, it makes sense and is useful to enable default-ssl.conf. Otherwise, trying to open https://freepbx.ip/ would result in a browser SSL error.