### PR TITLE
Add option --npmmirror

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -29,6 +29,7 @@ LOG_FOLDER="/var/log/pbx"
 LOG_FILE="${LOG_FOLDER}/freepbx17-install-$(date '+%Y.%m.%d-%H.%M.%S').log"
 log=$LOG_FILE
 SANE_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+NPM_MIRROR=""
 
 # Check for root privileges
 if [[ $EUID -ne 0 ]]; then
@@ -76,6 +77,10 @@ while [[ $# -gt 0 ]]; do
 			dahdi=true
 			shift # past argument
 			;;
+                --npmmirror)
+                        NPM_MIRROR=$2
+                        shift; shift
+                        ;;
 		-*)
 			echo "Unknown option $1"
 			exit 1
@@ -1073,6 +1078,11 @@ else
   setCurrentStep "Installing FreePBX 17"
   pkg_install ioncube-loader-82
   pkg_install freepbx17
+
+  if [ -n "$NPM_MIRROR" ] ; then
+    setCurrentStep "Setting environment variable npm_config_registry=$NPM_MIRROR"
+    export npm_config_registry="$NPM_MIRROR"
+  fi
 
   # Check if only opensource required then remove the commercial modules
   if [ "$opensourceonly" ]; then


### PR DESCRIPTION
In some countries, `npm install` times out if it downloads from the official npm registry, and the result is ugly. The UCP node.js script would spew error messages about missing modules, incurring heavy load on the system.

```
Module https://mirror.freepbx.org/modules/packages/ucp/ucp-17.0.4.23.tgz.gpg successfully downloaded
Updating tables ucp_sessions...Done
System : debian
Installing/Updating Required Libraries. This may take a while...The following messages are ONLY FOR DEBUGGING. Ignore anything that says 'WARN' or is just a warning
Running installation..
npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.
The process "runuser 'asterisk' -s '/bin/bash' -c 'cd /var/www/html/admin/modules/ucp/node && mkdir -p /home/asterisk/.pm2 && mkdir -p /var/www/html/admin/modules/ucp/node/logs && export HOME=/home/asterisk && export PM2_HOME=/home/asterisk/.pm2 && export ASTLOGDIR=/var/log/asterisk && export ASTVARLIBDIR=/var/lib/asterisk && export PATH=$HOME/.node/bin:$PATH && export NODE_PATH=$HOME/.node/lib/node_modules:$NODE_PATH && export MANPATH=$HOME/.node/share/man:$MANPATH && npm install --only=production'" exceeded the timeout of 600 seconds.
Failed updating libraries!
```