### PR TITLE
Added asterisk-version-switch pid check on apt post script

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -307,7 +307,11 @@ create_post_apt_script() {
     {
         echo "#!/bin/bash"
         echo ""
-        echo ""
+        echo "if pidof -x 'asterisk-version-switch' > /dev/null; then"
+	echo "echo \"Asterisk version switch process is running, skipping post-apt script.\""
+	echo "exit 0"
+	echo "fi"
+	echo ""
         echo "dahdi_pres=\$(dpkg -l | grep dahdi-linux | wc -l)"
         echo ""
         echo "if [[ \$dahdi_pres -gt 0 ]]; then"


### PR DESCRIPTION
The asterisk-version-switch fails due to the apt post script, so a check was added to skip the post apt script when the asterisk-version-switch is running.