### PR TITLE
Simplify VIM configuration for FreePBX 17 by using VIMRUNTIME

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -1068,9 +1068,6 @@ fi
 # Setting VIM configuration for mouse copy paste
 isVimRcAdapted=$(grep "FreePBX 17 changes" /etc/vim/vimrc.local |wc -l)
 if [ "0" = "${isVimRcAdapted}" ]; then
-	VIMRUNTIME=$(vim -e -T dumb --cmd 'exe "set t_cm=\<C-M>"|echo $VIMRUNTIME|quit' | tr -d '\015' )
-	VIMRUNTIME_FOLDER=$(echo "$VIMRUNTIME" | sed 's/ //g')
-
 	cat <<EOF >> /etc/vim/vimrc.local
 " FreePBX 17 changes - begin
 " This file loads the default vim options at the beginning and prevents
@@ -1079,7 +1076,7 @@ if [ "0" = "${isVimRcAdapted}" ]; then
 " whish at the end of this file.
 
 " Load the defaults
-source $VIMRUNTIME_FOLDER/defaults.vim
+source \$VIMRUNTIME/defaults.vim
 
 " Prevent the defaults from being loaded again later, if the user doesn't
 " have a local vimrc (~/.vimrc)


### PR DESCRIPTION
- Removed the manual extraction of the VIMRUNTIME folder.
- Updated vimrc.local to directly source defaults.vim using the VIMRUNTIME variable.
- This change allows VIM to handle the runtime path automatically, improving maintainability and reducing potential errors.