### PR TITLE
Use bookworm instead of stable repo

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -276,7 +276,7 @@ setup_repositories() {
 	fi
 
 	if [ ! "$noaac" ] ; then
-		add-apt-repository -y -S "deb $DEBIAN_MIRROR stable main non-free non-free-firmware" >> "$log"
+		add-apt-repository -y -S "deb $DEBIAN_MIRROR bookworm main non-free non-free-firmware" >> "$log"
 	fi
 
 	setCurrentStep "Setting up Sangoma repository"


### PR DESCRIPTION
Since Debian 13 was released on August 9th, we can no longer point to the `stable` repository. We must now specify the 'bookworm' repo to avoid an upgrade of Debian 12 to 13 during the script execution.

Fixes #189 