### PR TITLE
Avoid updating OS repos; install libfdk-aac from source instead

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -29,7 +29,6 @@ LOG_FOLDER="/var/log/pbx"
 LOG_FILE="${LOG_FOLDER}/freepbx17-install-$(date '+%Y.%m.%d-%H.%M.%S').log"
 log=$LOG_FILE
 SANE_PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
-DEBIAN_MIRROR="http://ftp.debian.org/debian"
 NPM_MIRROR=""
 
 # Check for root privileges
@@ -86,10 +85,6 @@ while [[ $# -gt 0 ]]; do
 		--nochrony)
 			nochrony=true
 			shift # past argument
-			;;
-		--debianmirror)
-			DEBIAN_MIRROR=$2
-			shift; shift # past argument
 			;;
     --npmmirror)
       NPM_MIRROR=$2
@@ -273,10 +268,6 @@ setup_repositories() {
 	else
 		add-apt-repository -y -S "deb [ arch=amd64 ] http://deb.freepbx.org/freepbx17-prod bookworm main" >> "$log"
 		add-apt-repository -y -S "deb [ arch=amd64 ] http://deb.freepbx.org/freepbx17-prod bookworm main" >> "$log"
-	fi
-
-	if [ ! "$noaac" ] ; then
-		add-apt-repository -y -S "deb $DEBIAN_MIRROR bookworm main non-free non-free-firmware" >> "$log"
 	fi
 
 	setCurrentStep "Setting up Sangoma repository"
@@ -1006,7 +997,12 @@ fi
 if [ "$noaac" ] ; then
 	message "Skipping libfdk-aac2 installation due to noaac option"
 else
-	pkg_install libfdk-aac2
+        pkg_install libtool
+        message "Building fdk-aac library..."
+        cd /usr/local/src
+        git clone https://github.com/mstorsjo/fdk-aac
+        cd fdk-aac
+        ./autogen.sh && ./configure && make && make install && ldconfig
 fi
 
 setCurrentStep "Removing unnecessary packages"


### PR DESCRIPTION
Addresses https://github.com/FreePBX/issue-tracker/issues/831 . Don't add the non-free repo just for the libfdk-aac package. Easy to build from source. Now there is no need to modify OS repos.

Install puts the compiled libraries in /usr/local/lib which is already part of the ld.so.conf library path.