### PR TITLE
Display last 10 lines of log on termination

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -257,6 +257,9 @@ setCurrentStep () {
 terminate() {
 	# removing pid file
 	message "Exiting script"
+    # display last 10 lines of the log file 
+	message "displaying last 10 lines from the log file"
+    tail -n 10 "$LOG_FILE"
 	rm -f "$pidfile"
 }
 


### PR DESCRIPTION
Add log display before script termination to help debugging, it's very frustrating to look for the log file, especially when there is a lot of them.