### PR TITLE
Updates the local package index after seting up Sangoma repos.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -380,6 +380,8 @@ setup_repositories() {
 	    block_debian13_trixie_update
 	fi
 
+	apt-get update >> "$log"
+
 	setCurrentStep "Setting up Sangoma repository"
     local aptpref="/etc/apt/preferences.d/99sangoma-fpbx-repository"
     cat <<EOF> $aptpref


### PR DESCRIPTION
This is needed now that `/etc/apt/sources.list` is manually setup.
Previously, using `add-apt-repository` this was not needed because that command performs the update.
Without this patch the latest DAHDI supported kernel is not reported on the console.