### PR TITLE
Add verbosity to removal of commercial modules.

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -1283,7 +1283,7 @@ else
   # Check if only opensource required then remove the commercial modules
   if [ "$opensourceonly" ]; then
     setCurrentStep "Removing commercial modules"
-    fwconsole ma list | awk '/Commercial/ {print $2}' | xargs -I {} fwconsole ma -f remove {} >> "$log"
+    fwconsole ma list | awk '/Commercial/ {print $2}' | xargs -t -I {} fwconsole ma -f remove {} >> "$log"
     # Remove firewall module also because it depends on commercial sysadmin module
     fwconsole ma -f remove firewall >> "$log" || true
   fi


### PR DESCRIPTION
On an `opensourceonly` install, if some commercial module fails to uninstall (like what is reported in #183), the log is not explicit were the failure happened.
Adding `-t` option to the `xargs` command gives more info on possible uninstall failures.