### PR TITLE
Improve logging

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -237,14 +237,17 @@ check_version() {
         esac
 }
 
-# Function to log messages
+# Functions to log messages
+echo_ts() {
+	echo "$(date +"%Y-%m-%d %T") - $*"
+}
+
 log() {
-	echo "$(date +"%Y-%m-%d %T") - $*" >> "$LOG_FILE"
+	echo_ts "$*" >> "$LOG_FILE"
 }
 
 message() {
-	echo "$(date +"%Y-%m-%d %T") - $*"
-	log "$*"
+	echo_ts "$*" | tee -a "$LOG_FILE"
 }
 
 #Function to record and display the current step
@@ -255,19 +258,21 @@ setCurrentStep () {
 
 # Function to cleanup installation
 terminate() {
+	# display last 10 lines of the log file on abnormal exits
+	if [ $? -ne 0 ]; then
+		echo_ts "Displaying last 10 lines from the log file"
+		tail -n 10 "$LOG_FILE"
+	fi
 	# removing pid file
-	message "Exiting script"
-    # display last 10 lines of the log file 
-	message "displaying last 10 lines from the log file"
-    tail -n 10 "$LOG_FILE"
 	rm -f "$pidfile"
+	message "Exiting script"
 }
 
 #Function to log error and location
 errorHandler() {
 	log "****** INSTALLATION FAILED *****"
-	message "Installation failed at step ${currentStep}. Please check log ${LOG_FILE} for details."
-	message "Error at line: $1 exiting with code $2 (last command was: $3)"
+	echo_ts "Installation failed at step ${currentStep}. Please check log ${LOG_FILE} for details."
+	log "Error at line: $1 exiting with code $2 (last command was: $3)"
 	exit "$2"
 }
 


### PR DESCRIPTION
Some improvements on the script logging:
- added `echo_ts()` function to show messages with timestamp only on console
- functions `log()` and `message()` are now based on `echo_ts()`
- tail log file on the console only on abnormal script exits (it was also done on success, which is not relevant)
- don't log the message `Please check log ${LOG_FILE} for details.` , as this is only relevant on console