### PR TITLE
Support dynamic Asterisk version selection for both script and ISO installs

### DIFF
--- a/sng_freepbx_debian_install.sh
+++ b/sng_freepbx_debian_install.sh
@@ -23,7 +23,7 @@
 #####################################################################################
 set -e
 SCRIPTVER="1.15"
-ASTVERSION=22
+ASTVERSION=${ASTVERSION:-22}
 PHPVERSION="8.2"
 LOG_FOLDER="/var/log/pbx"
 LOG_FILE="${LOG_FOLDER}/freepbx17-install-$(date '+%Y.%m.%d-%H.%M.%S').log"


### PR DESCRIPTION
This PR introduces dynamic selection of the Asterisk version to be installed in the FreePBX installer context. It modifies both the first-boot installation script and the ISO auto install GRUB configurations to allow specifying and adapting the Asterisk version seamlessly. The change supports existing scripted installs and ISO-based installs, ensuring consistent behaviour regardless of installation method.